### PR TITLE
Upgraded API Version, Removed SSL Type

### DIFF
--- a/lib/capital-iq/client.rb
+++ b/lib/capital-iq/client.rb
@@ -2,7 +2,7 @@ module CapitalIQ
   class Client
     attr_reader :cache
 
-    ENDPOINT = 'https://sdk.gds.standardandpoors.com/gdssdk/rest/v2/clientservice.json'
+    ENDPOINT = 'https://api-ciq.marketintelligence.spglobal.com/gdsapi/rest/v3/clientservice.json'.freeze
     include HTTParty
     format :json
 
@@ -15,11 +15,11 @@ module CapitalIQ
       # build request
       requests = [requests] unless requests.class == Array
       request_array = requests.collect { |r| r.to_hash }
-      request_body = {inputRequests: {inputRequests: request_array}.to_json}
+      request_body = {inputRequests: request_array}.to_json
 
       # send request
       response_data = from_cache(request_body) || self.class.post(
-          ENDPOINT, body: request_body, basic_auth: @auth, ssl_version: :TLSv1
+          ENDPOINT, body: request_body, basic_auth: @auth, headers: { 'Content-Type' => 'application/json' }
       ).parsed_response
 
       # analyze response


### PR DESCRIPTION
Based On CapIQ New `Service Advisory: API Cloud Migration`. We need to upgrade the API endpoint to V3 before **31st August 2018**.
Following changes are required based on new advisory email.

a.      Update end-point to https://api-ciq.marketintelligence.spglobal.com/gdsapi/rest/v3/clientservice.json

b.      Update Content-Type to application/json

c.      Update the input Request Format

- **OldFormat:** inputRequests={inputRequests:[{function:"GDSP",identifier:

"IBM:",mnemonic:"IQ_TOTAL_REV",properties:{PERIODTYPE:"IQ_FQ"}}]}

- **New Format:** {inputRequests:[{function:"GDSP",identifier:"IBM:",

mnemonic:" IQ_TOTAL_REV",properties:{PERIODTYPE:"IQ_FQ"}}]}
